### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ def versions = [
 ]
 
 ext {
-  log4JVersion = '2.16.0'
+  log4JVersion = '2.17.0'
 }
 
 dependencies {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105