### PR TITLE
Ecm-543 Fix test package name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verificatio
   classpath = sourceSets.functional.runtimeClasspath
 
   useJUnit {
-    includeCategories 'uk.gov.hmcts.ethos.ecm.consumer.functional.SmokeTest'
+    includeCategories 'uk.gov.hmcts.reform.ethos.ecm.consumer.functional.SmokeTest'
   }
 }
 
@@ -86,8 +86,8 @@ task functional(type: Test, description: 'Runs the functional tests.', group: 'V
   classpath = sourceSets.functional.runtimeClasspath
 
   useJUnit {
-    includeCategories 'uk.gov.hmcts.ethos.ecm.consumer.functional.SmokeTest'
-    includeCategories 'uk.gov.hmcts.ethos.ecm.consumer.functional.HealthCheckTest'
+    includeCategories 'uk.gov.hmcts.reform.ethos.ecm.consumer.functional.SmokeTest'
+    includeCategories 'uk.gov.hmcts.reform.ethos.ecm.consumer.functional.HealthCheckTest'
   }
 
   maxHeapSize = '1G'

--- a/src/test/functional/java/uk/gov/hmcts/ethos/ecm/consumer/functional/SmokeTest.java
+++ b/src/test/functional/java/uk/gov/hmcts/ethos/ecm/consumer/functional/SmokeTest.java
@@ -1,3 +1,0 @@
-package uk.gov.hmcts.ethos.ecm.consumer.functional;
-
-public interface SmokeTest { /* category marker */ }

--- a/src/test/functional/java/uk/gov/hmcts/reform/ethos/ecm/consumer/functional/HealthCheckTest.java
+++ b/src/test/functional/java/uk/gov/hmcts/reform/ethos/ecm/consumer/functional/HealthCheckTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.functional;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.functional;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/src/test/functional/java/uk/gov/hmcts/reform/ethos/ecm/consumer/functional/SmokeTest.java
+++ b/src/test/functional/java/uk/gov/hmcts/reform/ethos/ecm/consumer/functional/SmokeTest.java
@@ -1,0 +1,3 @@
+package uk.gov.hmcts.reform.ethos.ecm.consumer.functional;
+
+public interface SmokeTest { /* category marker */ }

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/helpers/Helper.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/helpers/Helper.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.helpers;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.helpers;
 
 import uk.gov.hmcts.ecm.common.model.servicebus.CreateUpdatesMsg;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/idam/TokenResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/idam/TokenResponseTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.ethos.ecm.consumer.idam;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.idam.TokenResponse;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/idam/TokenResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/idam/TokenResponseTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.idam;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.idam;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/AccessTokenServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.config.OAuth2Configuration;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.idam.TokenResponse;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.AccessTokenService;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/AccessTokenServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/EmailServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/EmailServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.config.EmailClient;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.MultipleErrors;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.EmailService;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/MultipleUpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/MultipleUpdateServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,10 +10,8 @@ import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
 import uk.gov.hmcts.ecm.common.model.multiples.SubmitMultipleEvent;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.MultipleErrors;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.MultipleUpdateService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.UserService;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/MultipleUpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/MultipleUpdateServiceTest.java
@@ -10,8 +10,8 @@ import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.model.multiples.MultipleData;
 import uk.gov.hmcts.ecm.common.model.multiples.SubmitMultipleEvent;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.MultipleErrors;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleCreationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleCreationServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.ccd.types.CasePreAcceptType;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleCreationService;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleReadingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleReadingServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,12 +10,7 @@ import uk.gov.hmcts.ecm.common.client.CcdClient;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleCreationService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleReadingService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleTransferService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleUpdateService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.UserService;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleTransferServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleTransferServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,8 +12,7 @@ import uk.gov.hmcts.ecm.common.model.ccd.CaseDetails;
 import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.ccd.types.CasePreAcceptType;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleTransferService;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 
 import java.io.IOException;
 

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleUpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/SingleUpdateServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,8 +11,7 @@ import uk.gov.hmcts.ecm.common.helpers.UtilHelper;
 import uk.gov.hmcts.ecm.common.model.ccd.CaseData;
 import uk.gov.hmcts.ecm.common.model.ccd.SubmitEvent;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleUpdateService;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 
 import java.io.IOException;
 

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UpdateManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UpdateManagementServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -8,14 +8,10 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
 import uk.gov.hmcts.ecm.common.model.servicebus.datamodel.ResetStateDataModel;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.MultipleErrors;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.repository.MultipleCounterRepository;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.repository.MultipleErrorsRepository;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.EmailService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.MultipleUpdateService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.SingleReadingService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.UpdateManagementService;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UpdateManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UpdateManagementServiceTest.java
@@ -8,10 +8,10 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
 import uk.gov.hmcts.ecm.common.model.servicebus.datamodel.ResetStateDataModel;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.MultipleErrors;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.repository.MultipleCounterRepository;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.domain.repository.MultipleErrorsRepository;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UserServiceTest.java
@@ -9,8 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.ecm.common.idam.models.UserDetails;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.idam.IdamApi;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.AccessTokenService;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.service.UserService;
 import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/service/UserServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.service;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.service;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/servicebus/MessageAutoCompletorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/servicebus/MessageAutoCompletorTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.servicebus.MessageAutoCompletor;
 
 import java.util.UUID;
 

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/servicebus/MessageAutoCompletorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/servicebus/MessageAutoCompletorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.servicebus;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.servicebus;
 
 import com.microsoft.azure.servicebus.IQueueClient;
 import org.junit.Before;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/CreateUpdatesBusReceiverTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/CreateUpdatesBusReceiverTaskTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.tasks;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.tasks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -16,9 +16,9 @@ import uk.gov.hmcts.ecm.common.model.servicebus.CreateUpdatesMsg;
 import uk.gov.hmcts.ecm.common.model.servicebus.Msg;
 import uk.gov.hmcts.ecm.common.servicebus.MessageBodyRetriever;
 import uk.gov.hmcts.ecm.common.servicebus.ServiceBusSender;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.servicebus.MessageAutoCompletor;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.tasks.CreateUpdatesBusReceiverTask;
+
 import java.io.IOException;
 
 import static java.util.Collections.singletonList;

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/UpdateCaseBusReceiverTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/UpdateCaseBusReceiverTaskTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.ethos.ecm.consumer.tasks;
+package uk.gov.hmcts.reform.ethos.ecm.consumer.tasks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -15,10 +15,10 @@ import uk.gov.hmcts.ecm.common.exceptions.InvalidMessageException;
 import uk.gov.hmcts.ecm.common.model.servicebus.Msg;
 import uk.gov.hmcts.ecm.common.model.servicebus.UpdateCaseMsg;
 import uk.gov.hmcts.ecm.common.servicebus.MessageBodyRetriever;
-import uk.gov.hmcts.ethos.ecm.consumer.helpers.Helper;
+import uk.gov.hmcts.reform.ethos.ecm.consumer.helpers.Helper;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.service.UpdateManagementService;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.servicebus.MessageAutoCompletor;
-import uk.gov.hmcts.reform.ethos.ecm.consumer.tasks.UpdateCaseBusReceiverTask;
+
 import java.io.IOException;
 
 import static java.util.Collections.singletonList;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ECM-543

### Change description ###

The package name hierarchy in test is incorrect. It does not match that used in main.
main: uk.gov.hmcts.reform.ethos.ecm.consumer
test: uk.gov.hmcts.ethos.ecm.consumer

The test package name hierarchy needs to be renamed so that it is
uk.gov.hmcts.reform.ethos.ecm.consumer

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
