### PR TITLE
cve suppression added

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -56,4 +56,11 @@
     <packageUrl regex="true">^pkg:maven/xalan/xalan@.*$</packageUrl>
     <cve>CVE-2022-34169</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: jackson-databind-2.13.4.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+  <cve>CVE-2022-42003</cve>
+</suppress>
 </suppressions>


### PR DESCRIPTION
CVE suppression added for CVE-2022-42003( jackson-databind-2.13.4).



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
