### PR TITLE
Multithreading 2

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ethos/ecm/consumer/config/ServiceBusCreateUpdatesReceiverConf.java
+++ b/src/main/java/uk/gov/hmcts/reform/ethos/ecm/consumer/config/ServiceBusCreateUpdatesReceiverConf.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.servicebus.IQueueClient;
 import com.microsoft.azure.servicebus.MessageHandlerOptions;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.ethos.ecm.consumer.tasks.CreateUpdatesBusReceiverTask;
@@ -17,8 +18,13 @@ import javax.annotation.PostConstruct;
 @Configuration
 public class ServiceBusCreateUpdatesReceiverConf {
 
+    @Value("${multithreading.create-updates-bus-receiver.maxConcurrentCalls}")
+    private int maxConcurrentCalls;
+
     @PostConstruct()
     public void registerMessageHandlers() throws InterruptedException, ServiceBusException {
+        MessageHandlerOptions messageHandlerOptions =
+            new MessageHandlerOptions(maxConcurrentCalls, false, Duration.ofMinutes(5));
         createUpdatesListenClient.registerMessageHandler(
             createUpdatesBusReceiverTask,
             messageHandlerOptions,
@@ -30,9 +36,6 @@ public class ServiceBusCreateUpdatesReceiverConf {
         Executors.newSingleThreadExecutor(r ->
                                               new Thread(r, "create-updates-queue-listen")
         );
-
-    private static final MessageHandlerOptions messageHandlerOptions =
-        new MessageHandlerOptions(1, false, Duration.ofMinutes(5));
 
     private final transient IQueueClient createUpdatesListenClient;
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -13,3 +13,9 @@ ccd_gateway_base_url = http://localhost:3455
 
 queue.create-updates.queue-name=${CREATE_UPDATES_QUEUE_NAME}
 queue.update-case.queue-name=${UPDATE_CASE_QUEUE_NAME}
+
+# MULTITHREADING
+multithreading.create-updates-bus-receiver.threads=${CREATE_UPDATES_BUS_THREADS:1}
+multithreading.update-case-bus-receiver.threads=${UPDATE_CASE_BUS_THREADS:1}
+multithreading.create-updates-bus-receiver.maxConcurrentCalls=${CREATE_UPDATES_BUS_MAX_CONCURRENT_CALLS:1}
+multithreading.update-case-bus-receiver.maxConcurrentCalls=${UPDATE_CASE_BUS_MAX_CONCURRENT_CALLS:1}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,11 @@ ccd_gateway_base_url = ${CCD_GATEWAY_BASE_URL:http://127.0.0.1:3453}
 caseWorkerUserName = ${CASEWORKER_USER_NAME:user_name}
 caseWorkerPassword = ${CASEWORKER_PASSWORD:password}
 
+# MULTITHREADING
+multithreading.create-updates-bus-receiver.threads=${CREATE_UPDATES_BUS_THREADS:10}
+multithreading.update-case-bus-receiver.threads=${UPDATE_CASE_BUS_THREADS:10}
+multithreading.create-updates-bus-receiver.maxConcurrentCalls=${CREATE_UPDATES_BUS_MAX_CONCURRENT_CALLS:10}
+multithreading.update-case-bus-receiver.maxConcurrentCalls=${UPDATE_CASE_BUS_MAX_CONCURRENT_CALLS:10}
 
 # QUEUES
 queue.create-updates.send.connection-string = ${CREATE_UPDATES_QUEUE_SEND_CONNECTION_STRING}

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/CreateUpdatesBusReceiverTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/CreateUpdatesBusReceiverTaskTest.java
@@ -31,8 +31,6 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class CreateUpdatesBusReceiverTaskTest {
 
-    @InjectMocks
-    private transient CreateUpdatesBusReceiverTask createUpdatesBusReceiverTask;
     @Mock
     private transient ObjectMapper objectMapper;
     @Mock
@@ -41,16 +39,18 @@ public class CreateUpdatesBusReceiverTaskTest {
     private transient ServiceBusSender serviceBusSender;
     @Mock
     private transient MultipleCounterRepository multipleCounterRepository;
+    @InjectMocks
+    private transient CreateUpdatesBusReceiverTask createUpdatesBusReceiverTask
+        = new CreateUpdatesBusReceiverTask(objectMapper,
+                                           messageCompletor,
+                                           serviceBusSender,
+                                           multipleCounterRepository, 10);
 
     private transient Message message;
     private transient CreateUpdatesMsg msg;
 
     @Before
     public void setUp() {
-        createUpdatesBusReceiverTask = new CreateUpdatesBusReceiverTask(objectMapper,
-                                                                        messageCompletor,
-                                                                        serviceBusSender,
-                                                                        multipleCounterRepository);
         msg = Helper.generateCreateUpdatesMsg();
         message = createMessage(msg);
     }

--- a/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/UpdateCaseBusReceiverTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ethos/ecm/consumer/tasks/UpdateCaseBusReceiverTaskTest.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class UpdateCaseBusReceiverTaskTest {
 
-    @InjectMocks
-    private transient UpdateCaseBusReceiverTask updateCaseBusReceiverTask;
     @Mock
     private transient ObjectMapper objectMapper;
     @Mock
@@ -38,13 +36,14 @@ public class UpdateCaseBusReceiverTaskTest {
     @Mock
     private transient UpdateManagementService updateManagementService;
 
+    @InjectMocks
+    private transient UpdateCaseBusReceiverTask updateCaseBusReceiverTask = new UpdateCaseBusReceiverTask(objectMapper,
+                                                                  messageCompletor,
+                                                                  updateManagementService, 10);
     private transient Message message;
 
     @Before
     public void setUp() {
-        updateCaseBusReceiverTask = new UpdateCaseBusReceiverTask(objectMapper,
-                                                                  messageCompletor,
-                                                                  updateManagementService);
         message = createMessage();
     }
 


### PR DESCRIPTION
Enable multithreading on ecm consumer to allow messages to be processed a lot quicker